### PR TITLE
feat: expose study data APIs and helper utilities

### DIFF
--- a/app/api/analytics/route.ts
+++ b/app/api/analytics/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server';
+import { loadAnalyticsSummary } from '../../../lib/getAnalytics';
+
+export async function GET() {
+  try {
+    const analytics = await loadAnalyticsSummary();
+    if (!analytics) {
+      return NextResponse.json({ error: 'Analytics not generated yet' }, { status: 404 });
+    }
+    return NextResponse.json(analytics);
+  } catch (error) {
+    console.error('Analytics API error', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/app/api/exam/form/route.ts
+++ b/app/api/exam/form/route.ts
@@ -1,0 +1,70 @@
+import { NextResponse } from 'next/server';
+import { loadBlueprint } from '../../../../lib/getBlueprint';
+import { loadStudyItems } from '../../../../lib/getItems';
+
+function parsePositiveInt(value: string | null, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isNaN(parsed) || parsed <= 0 ? fallback : parsed;
+}
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const length = parsePositiveInt(url.searchParams.get('length'), 20);
+  const seedParam = url.searchParams.get('seed');
+  const seed = seedParam ? Number.parseInt(seedParam, 10) : undefined;
+  const bankId = url.searchParams.get('bankId') ?? undefined;
+
+  try {
+    const [blueprint, itemsResult] = await Promise.all([
+      loadBlueprint(),
+      loadStudyItems({ bankId, includeEvidenceDataUri: false })
+    ]);
+
+    const { buildFormGreedy, isBlueprintFeasible } = (await import(
+      '../../../../scripts/lib/blueprint.mjs'
+    )) as typeof import('../../../../scripts/lib/blueprint.mjs');
+
+    const availableLength = Math.min(length, itemsResult.items.length);
+    if (availableLength === 0) {
+      return NextResponse.json(
+        { error: 'No items available for requested bank', bankId: itemsResult.bankId },
+        { status: 404 }
+      );
+    }
+
+    if (!isBlueprintFeasible(blueprint, itemsResult.items, availableLength)) {
+      return NextResponse.json(
+        { error: 'Blueprint infeasible with current item supply', bankId: itemsResult.bankId },
+        { status: 409 }
+      );
+    }
+
+    const form = buildFormGreedy({
+      blueprint,
+      items: itemsResult.items,
+      formLength: availableLength,
+      seed: seed && !Number.isNaN(seed) ? seed : 1
+    });
+
+    return NextResponse.json({
+      bankId: itemsResult.bankId,
+      blueprint: blueprint.id,
+      length: availableLength,
+      items: form.map((item) => ({
+        id: item.id,
+        stem: item.stem,
+        choices: item.choices,
+        key: item.key,
+        difficulty: item.difficulty,
+        los: item.los,
+        status: item.status,
+        rationale_correct: item.rationale_correct,
+        rationale_distractors: item.rationale_distractors
+      }))
+    });
+  } catch (error) {
+    console.error('Exam form API error', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/app/api/items/route.ts
+++ b/app/api/items/route.ts
@@ -1,0 +1,67 @@
+import { NextResponse } from 'next/server';
+import {
+  ItemBankNotFoundError,
+  type ItemDifficulty,
+  type ItemStatus,
+  loadStudyItems
+} from '../../../lib/getItems';
+
+function parseList(searchParams: URLSearchParams, key: string): string[] | undefined {
+  const values = searchParams.getAll(key);
+  if (!values.length) {
+    const single = searchParams.get(key);
+    if (!single) return undefined;
+    values.push(single);
+  }
+  const expanded = values
+    .flatMap((value) => value.split(',').map((entry) => entry.trim()))
+    .filter((value) => value.length > 0);
+  return expanded.length ? expanded : undefined;
+}
+
+const DIFFICULTY_SET = new Set<ItemDifficulty>(['easy', 'medium', 'hard']);
+const STATUS_SET = new Set<ItemStatus>(['draft', 'review', 'published']);
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const searchParams = url.searchParams;
+
+  const bankId = searchParams.get('bankId') ?? undefined;
+  const los = parseList(searchParams, 'los');
+  const difficultiesRaw = parseList(searchParams, 'difficulty');
+  const difficulties = difficultiesRaw
+    ?.filter((value): value is ItemDifficulty => DIFFICULTY_SET.has(value as ItemDifficulty));
+  const statusRaw = parseList(searchParams, 'status');
+  const status = statusRaw?.filter((value): value is ItemStatus => STATUS_SET.has(value as ItemStatus));
+  const includeEvidence = searchParams.get('includeEvidence') !== 'false';
+  const limitParam = searchParams.get('limit');
+  const limit = limitParam ? Number.parseInt(limitParam, 10) : undefined;
+
+  if (limit !== undefined && (Number.isNaN(limit) || limit < 0)) {
+    return NextResponse.json({ error: 'limit must be a non-negative integer' }, { status: 400 });
+  }
+
+  try {
+    const result = await loadStudyItems({
+      bankId: bankId ?? undefined,
+      los,
+      difficulties,
+      status,
+      limit,
+      includeEvidenceDataUri: includeEvidence
+    });
+
+    return NextResponse.json({
+      bankId: result.bankId,
+      total: result.total,
+      count: result.items.length,
+      items: result.items
+    });
+  } catch (error) {
+    if (error instanceof ItemBankNotFoundError) {
+      return NextResponse.json({ error: error.message }, { status: 404 });
+    }
+    console.error('Items API error', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/app/exam/page.tsx
+++ b/app/exam/page.tsx
@@ -2,7 +2,7 @@ import { loadStudyItems } from '../../lib/getItems';
 import { ExamView } from '../../components/ExamView';
 
 export default async function ExamPage() {
-  const items = await loadStudyItems();
+  const { items } = await loadStudyItems();
   return <ExamView items={items} length={20} />;
 }
 

--- a/app/study/page.tsx
+++ b/app/study/page.tsx
@@ -3,7 +3,7 @@ import { loadStudyItems } from '../../lib/getItems';
 import { StudyView } from '../../components/StudyView';
 
 export default async function StudyPage() {
-  const [items, analytics] = await Promise.all([loadStudyItems(), loadAnalyticsSummary()]);
+  const [{ items }, analytics] = await Promise.all([loadStudyItems(), loadAnalyticsSummary()]);
   return <StudyView items={items} analytics={analytics} />;
 }
 

--- a/lib/getBlueprint.ts
+++ b/lib/getBlueprint.ts
@@ -1,0 +1,28 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+export interface BlueprintConfig {
+  schema_version: string;
+  id: string;
+  weights: Record<string, number>;
+}
+
+const BLUEPRINT_PATH = path.join(process.cwd(), 'config', 'blueprint.json');
+
+export async function loadBlueprint(): Promise<BlueprintConfig> {
+  const raw = await fs.readFile(BLUEPRINT_PATH, 'utf8');
+  const blueprint = JSON.parse(raw) as BlueprintConfig;
+  if (!blueprint || typeof blueprint !== 'object') {
+    throw new Error('Invalid blueprint configuration');
+  }
+  if (!blueprint.schema_version) {
+    throw new Error('Blueprint missing schema_version');
+  }
+  if (!blueprint.id) {
+    throw new Error('Blueprint missing id');
+  }
+  if (!blueprint.weights || typeof blueprint.weights !== 'object' || !Object.keys(blueprint.weights).length) {
+    throw new Error('Blueprint missing LO weights');
+  }
+  return blueprint;
+}

--- a/lib/getItems.ts
+++ b/lib/getItems.ts
@@ -2,6 +2,20 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import type { AnalyticsSummary } from './getAnalytics';
 
+export type ItemDifficulty = 'easy' | 'medium' | 'hard';
+export type ItemStatus = 'draft' | 'review' | 'published';
+
+export interface StudyItemEvidence {
+  citation?: string;
+  cropPath?: string;
+  source_url?: string;
+  file?: string;
+  page?: number;
+  figure?: string;
+  bbox?: [number, number, number, number];
+  dataUri?: string;
+}
+
 export interface StudyItem {
   id: string;
   stem: string;
@@ -9,65 +23,150 @@ export interface StudyItem {
   key: 'A' | 'B' | 'C' | 'D' | 'E';
   rationale_correct: string;
   rationale_distractors: Partial<Record<'A' | 'B' | 'C' | 'D' | 'E', string>>;
-  difficulty: 'easy' | 'medium' | 'hard';
+  difficulty: ItemDifficulty;
+  bloom?: string;
   los: string[];
-  evidence?: {
-    citation?: string;
-    cropPath?: string;
-    source_url?: string;
-    file?: string;
-    page?: number;
-    figure?: string;
-    bbox?: [number, number, number, number];
-    dataUri?: string;
-  };
+  tags?: string[];
+  status: ItemStatus;
+  rubric_score?: number;
+  evidence?: StudyItemEvidence;
 }
 
-const BANK_DIR = path.join(process.cwd(), 'content', 'banks', 'upper-limb-oms1');
+export interface LoadStudyItemsOptions {
+  bankId?: string;
+  los?: string[];
+  difficulties?: ItemDifficulty[];
+  status?: ItemStatus[];
+  limit?: number;
+  includeEvidenceDataUri?: boolean;
+}
 
-async function loadEvidenceData(cropPath?: string): Promise<string | undefined> {
-  if (!cropPath) return undefined;
+export interface LoadStudyItemsResult {
+  bankId: string;
+  total: number;
+  items: StudyItem[];
+}
+
+export class ItemBankNotFoundError extends Error {
+  constructor(public bankId: string) {
+    super(`Item bank not found: ${bankId}`);
+    this.name = 'ItemBankNotFoundError';
+  }
+}
+
+const BANKS_ROOT = path.join(process.cwd(), 'content', 'banks');
+
+function resolveBankDir(bankId: string): string {
+  return path.join(BANKS_ROOT, bankId);
+}
+
+async function loadEvidenceData(cropPath: string | undefined, include: boolean): Promise<string | undefined> {
+  if (!cropPath || !include) return undefined;
   try {
     const fullPath = path.isAbsolute(cropPath) ? cropPath : path.join(process.cwd(), cropPath);
     const buffer = await fs.readFile(fullPath);
     const ext = path.extname(fullPath).toLowerCase();
-    const mime = ext === '.jpg' || ext === '.jpeg' ? 'image/jpeg' : ext === '.webp' ? 'image/webp' : ext === '.avif' ? 'image/avif' : 'image/png';
+    const mime =
+      ext === '.jpg' || ext === '.jpeg'
+        ? 'image/jpeg'
+        : ext === '.webp'
+        ? 'image/webp'
+        : ext === '.avif'
+        ? 'image/avif'
+        : 'image/png';
     return `data:${mime};base64,${buffer.toString('base64')}`;
   } catch {
     return undefined;
   }
 }
 
-export async function loadStudyItems(): Promise<StudyItem[]> {
-  const files = (await fs.readdir(BANK_DIR)).filter((file) => file.endsWith('.item.json')).sort();
-  const items: StudyItem[] = [];
-  for (const file of files) {
-    const raw = await fs.readFile(path.join(BANK_DIR, file), 'utf8');
-    const json = JSON.parse(raw);
-    const evidence = json.evidence ?? {};
-    const dataUri = await loadEvidenceData(evidence.cropPath);
-    items.push({
-      id: json.id,
-      stem: json.stem,
-      choices: json.choices,
-      key: json.key,
-      rationale_correct: json.rationale_correct,
-      rationale_distractors: json.rationale_distractors ?? {},
-      difficulty: json.difficulty,
-      los: json.los,
+const VALID_STATUSES: ItemStatus[] = ['draft', 'review', 'published'];
+
+function normalizeStatus(status: unknown): ItemStatus {
+  if (typeof status === 'string' && (VALID_STATUSES as string[]).includes(status)) {
+    return status as ItemStatus;
+  }
+  return 'draft';
+}
+
+export async function loadStudyItems(options: LoadStudyItemsOptions = {}): Promise<LoadStudyItemsResult> {
+  const {
+    bankId = 'upper-limb-oms1',
+    los,
+    difficulties,
+    status,
+    limit,
+    includeEvidenceDataUri = true
+  } = options;
+
+  const bankDir = resolveBankDir(bankId);
+  let fileNames: string[];
+  try {
+    fileNames = (await fs.readdir(bankDir)).filter((file) => file.endsWith('.item.json')).sort();
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      throw new ItemBankNotFoundError(bankId);
+    }
+    throw error;
+  }
+
+  const filtered: StudyItem[] = [];
+  const losFilter = los && los.length ? new Set(los) : null;
+  const difficultyFilter = difficulties && difficulties.length ? new Set(difficulties) : null;
+  const statusFilter = status && status.length ? new Set(status) : null;
+
+  for (const file of fileNames) {
+    const raw = await fs.readFile(path.join(bankDir, file), 'utf8');
+    const json = JSON.parse(raw) as Record<string, unknown>;
+
+    const itemLos = Array.isArray(json.los) ? (json.los as string[]) : [];
+    if (losFilter && !itemLos.some((lo) => losFilter.has(lo))) {
+      continue;
+    }
+
+    const difficulty = json.difficulty as ItemDifficulty | undefined;
+    if (difficultyFilter && (!difficulty || !difficultyFilter.has(difficulty))) {
+      continue;
+    }
+
+    const itemStatus = normalizeStatus(json.status);
+    if (statusFilter && !statusFilter.has(itemStatus)) {
+      continue;
+    }
+
+    const evidence = (json.evidence as Record<string, unknown> | undefined) ?? {};
+    const dataUri = await loadEvidenceData(evidence.cropPath as string | undefined, includeEvidenceDataUri);
+
+    filtered.push({
+      id: json.id as string,
+      stem: json.stem as string,
+      choices: json.choices as StudyItem['choices'],
+      key: json.key as StudyItem['key'],
+      rationale_correct: json.rationale_correct as string,
+      rationale_distractors: (json.rationale_distractors as StudyItem['rationale_distractors']) ?? {},
+      difficulty: (difficulty ?? 'medium') as ItemDifficulty,
+      bloom: json.bloom as string | undefined,
+      los: itemLos,
+      tags: (json.tags as string[]) ?? [],
+      status: itemStatus,
+      rubric_score: json.rubric_score as number | undefined,
       evidence: {
-        citation: evidence.citation,
-        cropPath: evidence.cropPath,
-        source_url: evidence.source_url,
-        file: evidence.file,
-        page: evidence.page,
-        figure: evidence.figure,
-        bbox: evidence.bbox,
+        citation: evidence.citation as string | undefined,
+        cropPath: evidence.cropPath as string | undefined,
+        source_url: evidence.source_url as string | undefined,
+        file: evidence.file as string | undefined,
+        page: evidence.page as number | undefined,
+        figure: evidence.figure as string | undefined,
+        bbox: evidence.bbox as [number, number, number, number] | undefined,
         dataUri
       }
     });
   }
-  return items;
+
+  const total = filtered.length;
+  const items = typeof limit === 'number' ? filtered.slice(0, Math.max(0, limit)) : filtered;
+
+  return { bankId, total, items };
 }
 
 export type { AnalyticsSummary };

--- a/tests/getItems.test.ts
+++ b/tests/getItems.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { ItemBankNotFoundError, loadStudyItems } from '../lib/getItems';
+
+describe('loadStudyItems', () => {
+  it('returns items with metadata', async () => {
+    const { items, total, bankId } = await loadStudyItems();
+    expect(bankId).toBe('upper-limb-oms1');
+    expect(total).toBeGreaterThan(0);
+    expect(items.length).toBeGreaterThan(0);
+    expect(items[0]).toHaveProperty('status');
+  });
+
+  it('filters by LO identifiers', async () => {
+    const targetLo = 'lo.radial-nerve';
+    const { items, total } = await loadStudyItems({ los: [targetLo] });
+    expect(total).toBe(items.length);
+    expect(items.every((item) => item.los.includes(targetLo))).toBe(true);
+  });
+
+  it('filters by difficulty and applies limits', async () => {
+    const { items } = await loadStudyItems({ difficulties: ['easy'], limit: 2 });
+    expect(items.length).toBeLessThanOrEqual(2);
+    expect(items.every((item) => item.difficulty === 'easy')).toBe(true);
+  });
+
+  it('throws when the bank directory is missing', async () => {
+    await expect(loadStudyItems({ bankId: 'does-not-exist' })).rejects.toBeInstanceOf(
+      ItemBankNotFoundError
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add API routes for items, analytics, and blueprint-driven exam forms
- extend study item loader with filtering, metadata, and blueprint helper
- add unit coverage for loader behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d90d076e48832f8df5fa36ed7f551f