### PR TITLE
feat: add analytics item recommendations

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -16,6 +16,7 @@
 - Refine TTM/ELG/min definitions
 - Confusion graphs, speed×accuracy
 - ELG/min playlists + reasons
+- Item-level "why this next" recommendations generated via analyze pipeline (score tuning ongoing)
 
 4) Governance & CI — IN PROGRESS
 - CI: build, validate, unit, analyze, e2e axe, Lighthouse
@@ -25,7 +26,7 @@
 
 - UI: finish Radix adoption across Study/Exam/Drill views; audit focus traps and keyboard paths after tooltip/dialog refactor.
 - Evidence: replace placeholder crops with real assets; add `source_url`; flip items to `review`/`published`.
-- Analytics: enrich `data/events.ndjson`, rerun analyze, iterate chart formats & tooltips.
+- Analytics: calibrate new recommendation scoring, enrich `data/events.ndjson`, rerun analyze, iterate chart formats & tooltips.
 - Exam polish: add timer + blueprint meter; lock evidence; post‑submit score.
 - Summary polish: optional canvas confusion graph; add chart tooltips/legends if analytics grow.
 - CI: monitor Lighthouse thresholds (perf ≥0.75, a11y ≥0.9) and tighten over time; keep axe serious+ gating green.

--- a/README.md
+++ b/README.md
@@ -102,7 +102,9 @@ Engine behavior is covered by `npm test` smoke tests. Update these modules befor
   - LO IDs exist in `config/los.json`
   - published items must have `rubric_score ≥ 2.7`
   - To relax evidence during setup: run with `REQUIRE_EVIDENCE_CROP=0` to allow citation‑only (must include `citation` or `source_url`)
-- `npm run analyze` reads `data/events.ndjson` (if present) and writes placeholder analytics to `public/analytics/latest.json`.
+- `npm run analyze` reads `data/events.ndjson` (if present) and writes analytics to `public/analytics/latest.json`, including LO
+  projections, confusion edges, ELG/min, and item-level recommendations with reason types (spacing, mastery deficit, ELG boost,
+  recency, accuracy, or general momentum).
 - `npm run dev` auto-opens the app in your default browser (set `DEV_URL` to override) — use `npm run dev:start` to run without auto-opening.
 
 ## Next Steps

--- a/components/StudyView.tsx
+++ b/components/StudyView.tsx
@@ -25,6 +25,10 @@ interface ChoiceFeedback {
 
 function getWhyThisNext(itemId: string, itemLOs: string[], analytics: AnalyticsSummary | null): string {
   if (!analytics) return 'Focus on mastery — keep practicing.';
+  const recommendation = analytics.item_recommendations?.find((rec) => rec.item_id === itemId);
+  if (recommendation) {
+    return recommendation.reason;
+  }
   // Spacing: if any LO is overdue
   const overdue = (analytics.ttm_per_lo || []).filter((t) => itemLOs.includes(t.lo_id) && t.overdue);
   if (overdue.length > 0) {

--- a/lib/getAnalytics.ts
+++ b/lib/getAnalytics.ts
@@ -43,6 +43,20 @@ export interface AnalyticsSummary {
     pick_rate: number;
     attempts: number;
   }>;
+  item_recommendations: Array<{
+    item_id: string;
+    lo_ids: string[];
+    attempts: number;
+    accuracy: number;
+    avg_duration_seconds: number;
+    last_attempt_ts: number | null;
+    projected_minutes_to_mastery: number;
+    overdue_lo_ids: string[];
+    reason: string;
+    reason_type: 'spacing' | 'mastery_deficit' | 'elg' | 'recency' | 'accuracy' | 'momentum';
+    score: number;
+    elg_rank: number | null;
+  }>;
 }
 
 export async function loadAnalyticsSummary(): Promise<AnalyticsSummary | null> {

--- a/tests/analyze.test.mjs
+++ b/tests/analyze.test.mjs
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { summarize } from '../scripts/analyze.mjs';
+
+const baseAttempt = {
+  schema_version: '1.0.0',
+  app_version: '1.0.0',
+  session_id: 'session-1',
+  user_id: 'user-1',
+  mode: 'learn',
+  opened_evidence: true,
+  choice: 'A'
+};
+
+describe('analytics summarize', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-01-01T00:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('produces item recommendations with mastery deficit reasons', () => {
+    const dayMs = 1000 * 60 * 60 * 24;
+    const attempts = [
+      {
+        ...baseAttempt,
+        item_id: 'item-alpha',
+        lo_ids: ['lo.alpha'],
+        ts_start: Date.now() - dayMs * 2 - 60000,
+        ts_submit: Date.now() - dayMs * 2,
+        duration_ms: 60000,
+        correct: false
+      },
+      {
+        ...baseAttempt,
+        item_id: 'item-alpha',
+        lo_ids: ['lo.alpha'],
+        ts_start: Date.now() - dayMs - 60000,
+        ts_submit: Date.now() - dayMs,
+        duration_ms: 60000,
+        correct: true
+      }
+    ];
+
+    const summary = summarize(attempts);
+    expect(summary.has_events).toBe(true);
+    const ttm = summary.ttm_per_lo.find((entry) => entry.lo_id === 'lo.alpha');
+    expect(ttm).toBeDefined();
+    expect(ttm?.projected_minutes_to_mastery).toBeGreaterThan(0);
+
+    const recommendation = summary.item_recommendations.find((entry) => entry.item_id === 'item-alpha');
+    expect(recommendation).toBeDefined();
+    expect(recommendation?.reason_type).toBe('mastery_deficit');
+    expect(recommendation?.reason).toContain('lo.alpha');
+    expect(recommendation?.projected_minutes_to_mastery).toBeCloseTo(ttm?.projected_minutes_to_mastery ?? 0, 5);
+    expect(recommendation?.score ?? 0).toBeGreaterThan(0);
+  });
+
+  it('flags spacing recency when attempts are stale', () => {
+    const dayMs = 1000 * 60 * 60 * 24;
+    const attempts = [
+      {
+        ...baseAttempt,
+        item_id: 'item-beta',
+        lo_ids: ['lo.beta'],
+        ts_start: Date.now() - dayMs * 5 - 45000,
+        ts_submit: Date.now() - dayMs * 5,
+        duration_ms: 45000,
+        correct: true
+      }
+    ];
+
+    const summary = summarize(attempts);
+    const recommendation = summary.item_recommendations.find((entry) => entry.item_id === 'item-beta');
+    expect(recommendation).toBeDefined();
+    expect(recommendation?.reason_type).toBe('spacing');
+    expect(recommendation?.reason).toContain('Spacing overdue');
+    expect(recommendation?.overdue_lo_ids).toEqual(['lo.beta']);
+  });
+});


### PR DESCRIPTION
## Summary
- extend the analytics script to build item-level "why this next" recommendations with scoring and expose the helper for tests
- surface the new recommendation data through the analytics loader and Study view while documenting the pipeline updates
- add unit coverage for the summarize helper and update the project plan to reflect the backend work

## Testing
- npm test
- npm run validate:items
- npm run analyze

------
https://chatgpt.com/codex/tasks/task_e_68d912a4e784832fb23b22cb4ddbda41