### PR TITLE
feat(study): add deterministic ‘Why this next’ pill component and tests

### DIFF
--- a/components/pills/WhyThisNextPill.tsx
+++ b/components/pills/WhyThisNextPill.tsx
@@ -1,0 +1,56 @@
+"use client";
+import * as React from 'react';
+
+export interface WhySignals {
+  info: number;
+  blueprintMult: number;
+  exposureMult: number;
+  fatigue: number;
+  medianSec: number;
+  thetaHat: number;
+  se: number;
+  masteryProb: number;
+  loIds: string[];
+  itemId: string;
+}
+
+export function WhyThisNextPill({ signals, onClick }: { signals: WhySignals; onClick?: () => void }) {
+  const parts = [
+    { label: 'Info', value: signals.info.toFixed(2), key: 'info' },
+    { label: 'Blueprint×', value: signals.blueprintMult.toFixed(2), key: 'blueprint' },
+    { label: 'Exposure×', value: signals.exposureMult.toFixed(2), key: 'exposure' },
+    { label: 'Median', value: `${signals.medianSec.toFixed(0)}s`, key: 'median' },
+    { label: 'θ̂', value: signals.thetaHat.toFixed(2), key: 'theta' },
+    { label: 'SE', value: signals.se.toFixed(2), key: 'se' },
+    { label: 'Mastery', value: signals.masteryProb.toFixed(2), key: 'mastery' }
+  ];
+
+  const aria = `Why this next for ${signals.itemId}: ` +
+    parts.map((p) => `${p.label}${p.label.endsWith('×') ? '' : '='}${p.value}`).join(', ');
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={onClick}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') onClick?.();
+      }}
+      aria-label={aria}
+      className="flex flex-wrap items-center gap-2"
+    >
+      {parts.map((p) => (
+        <span
+          key={p.key}
+          className="okc-pill"
+          data-why-next={p.key}
+          title={`${p.label}${p.label.endsWith('×') ? '' : ' = '}${p.value}`}
+        >
+          <span className="opacity-70">{p.label}</span>
+          <span>{p.value}</span>
+        </span>
+      ))}
+    </div>
+  );
+}
+

--- a/lib/server/forms.ts
+++ b/lib/server/forms.ts
@@ -122,6 +122,12 @@ export async function buildExamForm({ length, seed = 1, publishedOnly = false }:
     throw new BlueprintDeficitError(blueprint.id, ['No items available matching publishedOnly filter']);
   }
 
+  // Guard: even if per-LO supply is feasible, total distinct items must meet requested length
+  if (pool.length < length) {
+    const deficits = computeDeficits(blueprint, pool, length);
+    throw new BlueprintDeficitError(blueprint.id, deficits);
+  }
+
   if (!isBlueprintFeasible(blueprint, pool, length)) {
     const deficits = computeDeficits(blueprint, pool, length);
     throw new BlueprintDeficitError(blueprint.id, deficits);

--- a/tests/why-pill.test.tsx
+++ b/tests/why-pill.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+import { WhyThisNextPill } from '../components/pills/WhyThisNextPill';
+
+describe('WhyThisNextPill', () => {
+  it('renders compact numeric chips deterministically', () => {
+    const html = renderToString(
+      <WhyThisNextPill
+        signals={{
+          info: 0.37,
+          blueprintMult: 1.1,
+          exposureMult: 0.85,
+          fatigue: 0.90,
+          medianSec: 75,
+          thetaHat: 0.12,
+          se: 0.30,
+          masteryProb: 0.72,
+          loIds: ['lo.ulnar-nerve'],
+          itemId: 'item.ulnar.claw-hand'
+        }}
+      />
+    );
+    expect(html).toContain('Info');
+    expect(html).toContain('0.37');
+    expect(html).toContain('Blueprint×');
+    expect(html).toContain('1.10');
+    expect(html).toContain('Exposure×');
+    expect(html).toContain('0.85');
+    expect(html).toContain('Median');
+    expect(html).toContain('75s');
+    expect(html).toContain('θ̂');
+    expect(html).toContain('0.12');
+    expect(html).toContain('SE');
+    expect(html).toContain('0.30');
+    expect(html).toContain('Mastery');
+    expect(html).toContain('0.72');
+  });
+});
+


### PR DESCRIPTION
Summary
- Add deterministic “Why this next” pill component to Study, rendering numeric rationale chips (Info, Blueprint×, Exposure×, Median s, θ̂, SE, Mastery). No runtime LLM calls.

Scope
- components/pills/WhyThisNextPill.tsx (new)
- components/StudyView.tsx (wire pill; keep popover text)
- tests/why-pill.test.tsx (SSR render test)
- lib/server/forms.ts (guard: reject when publishedOnly pool < requested length)
- IMPLEMENTATION.md (scoped plan appended)

Acceptance gates (local)
- Tests: ✓ 12 files, 35 tests passed (vitest)
- Determinism: reads public/analytics/latest.json; no runtime network/LLM
- Validator/analytics: unchanged; no item/evidence edits; schema_version intact

Why
- High-ROI, low-risk UX improvement that raises transparency/trust using existing analytics; ships in a tiny PR with tests and keeps main green.

How to verify
```bash
npm ci
npm run analyze  # ensure latest.json exists
npm test
npm run dev
# Visit /study → “Why this next” pill shows numeric chips
```

Notes
- Forms guard: `lib/server/forms.ts` now surfaces deficits when publishedOnly pool is smaller than requested length — prevents false-positive feasibility.