### PR TITLE
docs(pm): add session handoff and PLAN milestones (#13/#14)

### DIFF
--- a/NEXT_SESSION.md
+++ b/NEXT_SESSION.md
@@ -1,0 +1,38 @@
+# Session Handoff — 2025-10-02
+
+## State
+- Main is green; branch protection requires the “build” job.
+- Merged PRs today: #13 (Health Check CI), #14 (“Why this next” pill UI).
+- Validator: ✓ 0 errors; Analytics: refreshed deterministically; Tests: all passing locally.
+
+## What Shipped
+- Deterministic rationale pill in Study (no runtime LLM or network reads).
+- PR template with acceptance gates; branch protection enforcing build.
+
+## Recommended Next (ROI-checked)
+- 🔥 Implement pill polish and analytics fallbacks (High ROI)
+  - Scope: `components/pills/WhyThisNextPill.tsx`, `components/StudyView.tsx`
+  - Add tooltip with per-LO TTM summary when available; clamp text.
+- ✅ CI tune-up: confirm step ordering & caching (Medium–High ROI)
+  - Scope: `.github/workflows/ci.yml` — ensure validate → analyze → test → build; keep caches.
+- ✳️ Nightly analytics snapshot action (Medium ROI)
+  - Scope: `.github/workflows/nightly-analytics.yml` — write latest.json artifact nightly.
+
+## Commands
+```bash
+npm ci
+npm run validate:items
+npm run analyze
+npm test
+npm run dev
+```
+
+## Next Agent Lines
+- Next agent: UIBuilder · Model: gpt-5-codex-high · Scope: components/pills/WhyThisNextPill.tsx components/StudyView.tsx
+- Next agent: ReleaseManager · Model: gpt-5-codex-high · Scope: .github/workflows/**
+- Next agent: ProjectManager · Model: gpt-5-codex-high · Scope: PLAN.md
+
+## Notes
+- Keep `public/analytics/latest.json` ignored; rely on artifacts or local refreshes.
+- Do not alter clinical text/evidence without SME review; validator remains a hard gate.
+

--- a/PLAN.md
+++ b/PLAN.md
@@ -6,6 +6,28 @@
 ## Recent Merge Log
 - Latest — OKC-heavy UI, analytics cards, lessons scaffolding landed; GLTFLoader CDN fixed; analytics regenerated.
 
+### 2025-10-02 — Health Check CI PR (#13)
+- Finalized GET `/api/health` + test; CI build green; Vercel deploy ok.
+- Outcome: added durable CI signal for future PRs.
+
+### 2025-10-02 — “Why this next” Pill UI PR (#14)
+- Added deterministic pill component (no runtime LLM); wired into StudyView; tests added.
+- Guarded exam form builder to surface deficits when published-only pool is too small.
+- Outcome: transparency increase with minimal risk; main remains green via required build check.
+
+## Milestone — 2025-10-02 · Health Check CI PR
+- Branch: `feat/health-check-ci` (local). Scope: `app/api/health/route.ts`, `tests/api/health.test.ts`.
+- Validator: ✓ 0 errors (30 items). Blueprint tracked; statuses {review: 4, draft: 26}.
+- Analyze: ✓ `public/analytics/latest.json` refreshed deterministically (primary delta `generated_at`).
+- Tests: ✓ 10 files, 33 tests passed (vitest).
+- Integrity: no item edits; `schema_version`/evidence unchanged; clinical text/rationales untouched.
+
+Next agent: ReleaseManager · Model: gpt-5-codex-high · Scope: app/api/** tests/api/**
+- Actions: open PR “feat(api): harden health check and add test”; verify CI (validate/analyze/tests) and merge if green.
+
+Next agent: ProjectManager · Model: gpt-5-codex-high · Scope: PLAN.md docs/**
+- Actions: track follow-ups — (1) LO extractor kick-off, (2) “Why this next” pill wiring using `public/analytics/latest.json`, (3) schedule analytics refresh.
+
 ## Module Inputs
 - MODULE: <fill at epic kickoff>
 - SYSTEM/SECTION: <optional>


### PR DESCRIPTION
Housekeeping
- PLAN.md: added milestones for #13 and #14 (dates, outcomes)
- NEXT_SESSION.md: handoff with current state, recommended next actions, and next agents

Why
- Keeps cadence visible; prepares next session for fast start; aligns with PM excellence rubric.

No code changes to runtime; docs only.